### PR TITLE
Stream implementation

### DIFF
--- a/src/LibYear.Lib/FileTypes/CsProjStream.cs
+++ b/src/LibYear.Lib/FileTypes/CsProjStream.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace LibYear.Lib.FileTypes
+{
+    public class CsProjStream : XmlProject
+    {
+        public CsProjStream(Stream fileStream) : base(fileStream, "PackageReference", "Include", "Version")
+        {
+        }
+    }
+}

--- a/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
+++ b/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace LibYear.Lib.FileTypes
+{
+    public class PackagesConfigStream : XmlProject
+    {
+        public PackagesConfigStream(Stream fileStream) : base(fileStream, "package", "id", "version")
+        {
+        }
+    }
+}

--- a/src/LibYear.Lib/FileTypes/XmlProject.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProject.cs
@@ -9,16 +9,15 @@ namespace LibYear.Lib.FileTypes
 {
     public abstract class XmlProject : IProjectFile
     {
-        public virtual string FileName => throw new NotSupportedException();
         protected readonly XDocument _xmlContents;
         protected readonly Stream _underlyingStreamData;
+        public virtual string FileName => throw new NotSupportedException();
         public IDictionary<string, NuGetVersion> Packages { get; protected set; }
 
         public XmlProject(Stream fileStream, string elementName, string packageAttributeName, string versionAttributeName)
         {
             _underlyingStreamData = fileStream;
             _xmlContents = XDocument.Load(fileStream);
-
 
             Packages = _xmlContents.Descendants(elementName)
                 .ToDictionary(d => d.Attribute(packageAttributeName)?.Value ?? d.Element(packageAttributeName)?.Value,

--- a/src/LibYear.Lib/FileTypes/XmlProject.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProject.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuGet.Versioning;
+
+namespace LibYear.Lib.FileTypes
+{
+    public abstract class XmlProject : IProjectFile
+    {
+        public virtual string FileName => throw new NotSupportedException();
+        protected readonly XDocument _xmlContents;
+        protected readonly Stream _underlyingStreamData;
+        public IDictionary<string, NuGetVersion> Packages { get; protected set; }
+
+        public XmlProject(Stream fileStream, string elementName, string packageAttributeName, string versionAttributeName)
+        {
+            _underlyingStreamData = fileStream;
+            _xmlContents = XDocument.Load(fileStream);
+
+
+            Packages = _xmlContents.Descendants(elementName)
+                .ToDictionary(d => d.Attribute(packageAttributeName)?.Value ?? d.Element(packageAttributeName)?.Value,
+                    d => new NuGetVersion(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value));
+        }
+
+        public virtual void Update(IEnumerable<Result> results) => throw new NotSupportedException();
+    }
+}

--- a/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
@@ -9,7 +9,6 @@ namespace LibYear.Lib.FileTypes
         private readonly string _elementName;
         private readonly string _packageAttributeName;
         private readonly string _versionAttributeName;
-
         public override string FileName { get; }
 
         protected XmlProjectFile(string filename, string elementName, string packageAttributeName, string versionAttributeName)
@@ -21,8 +20,8 @@ namespace LibYear.Lib.FileTypes
             _packageAttributeName = packageAttributeName;
             _versionAttributeName = versionAttributeName;
 
-            //Don't like this, but don't want to do it in the base class
-            //as I would prefer consumers handle the lifeteam of the stream
+            // Don't like this, but don't want to do it in the base class
+            // as I would prefer consumers handle the lifetime of the stream
             _underlyingStreamData.Dispose();
         }
 

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LibYear.Lib.FileTypes;
+using Xunit;
+
+namespace LibYear.Lib.Tests.FileTypes
+{
+    public class CsProjProjectStreamTests
+    {
+        private static System.IO.Stream LoadStreamFromFile(string fileName)
+        {
+            return System.IO.File.OpenRead(fileName);
+        }
+
+        [Fact]
+        public void CanLoadCsProjStream()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
+
+                //assert
+                Assert.Equal("test1", csprojStream.Packages.First().Key);
+                Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
+                Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
+            }
+        }
+
+        [Fact]
+        public void AttemptingToReadFileNameWillThrowNotSupportedException()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
+
+                //assert
+                Assert.Throws<NotSupportedException>(() => csprojStream.FileName);
+            }
+        }
+
+        [Fact]
+        public void AttemptingToUpdateWillThrowNotSupportedException()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
+
+                //assert
+                Assert.Throws<NotSupportedException>(() => csprojStream.Update(new List<Result>()));
+            }
+        }
+    }
+}

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using LibYear.Lib.FileTypes;
 using Xunit;
@@ -8,17 +9,12 @@ namespace LibYear.Lib.Tests.FileTypes
 {
     public class CsProjProjectStreamTests
     {
-        private static System.IO.Stream LoadStreamFromFile(string fileName)
-        {
-            return System.IO.File.OpenRead(fileName);
-        }
-
         [Fact]
         public void CanLoadCsProjStream()
         {
             //arrange
             const string filename = "FileTypes\\project.csproj";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var csprojStream = new CsProjStream(stream);
@@ -35,7 +31,7 @@ namespace LibYear.Lib.Tests.FileTypes
         {
             //arrange
             const string filename = "FileTypes\\project.csproj";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var csprojStream = new CsProjStream(stream);
@@ -50,7 +46,7 @@ namespace LibYear.Lib.Tests.FileTypes
         {
             //arrange
             const string filename = "FileTypes\\project.csproj";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var csprojStream = new CsProjStream(stream);

--- a/test/LibYear.Lib.Tests/FileTypes/PackagesConfigStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/PackagesConfigStreamTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LibYear.Lib.FileTypes;
+using Xunit;
+
+namespace LibYear.Lib.Tests.FileTypes
+{
+    public class PackagesConfigStreamTests
+    {
+        private static System.IO.Stream LoadStreamFromFile(string fileName)
+        {
+            return System.IO.File.OpenRead(fileName);
+        }
+
+        [Fact]
+        public void CanLoadPackagesConfigStream()
+        {
+            //arrange
+            const string filename = "FileTypes\\packages.config";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var packagesConfigStream = new PackagesConfigStream(stream);
+
+                //assert
+                Assert.Equal("test1", packagesConfigStream.Packages.First().Key);
+                Assert.Equal("test2", packagesConfigStream.Packages.Skip(1).First().Key);
+                Assert.Equal("test3", packagesConfigStream.Packages.Skip(2).First().Key);
+            }
+        }
+
+        [Fact]
+        public void AttemptingToReadFileNameWillThrowNotSupportedException()
+        {
+            //arrange
+            const string filename = "FileTypes\\packages.config";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var packagesConfigStream = new PackagesConfigStream(stream);
+
+                //Assert
+                Assert.Throws<NotSupportedException>(() => packagesConfigStream.FileName);
+            }
+        }
+
+        [Fact]
+        public void AttemptingToUpdateWillThrowNotSupportedException()
+        {
+            //arrange
+            const string filename = "FileTypes\\packages.config";
+            using (var stream = LoadStreamFromFile(filename))
+            {
+                //act
+                var packagesConfigStream = new PackagesConfigStream(stream);
+
+                //assert
+                Assert.Throws<NotSupportedException>(() => packagesConfigStream.Update(new List<Result>()));
+            }
+        }
+    }
+}

--- a/test/LibYear.Lib.Tests/FileTypes/PackagesConfigStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/PackagesConfigStreamTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using LibYear.Lib.FileTypes;
 using Xunit;
@@ -8,17 +9,12 @@ namespace LibYear.Lib.Tests.FileTypes
 {
     public class PackagesConfigStreamTests
     {
-        private static System.IO.Stream LoadStreamFromFile(string fileName)
-        {
-            return System.IO.File.OpenRead(fileName);
-        }
-
         [Fact]
         public void CanLoadPackagesConfigStream()
         {
             //arrange
             const string filename = "FileTypes\\packages.config";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var packagesConfigStream = new PackagesConfigStream(stream);
@@ -35,7 +31,7 @@ namespace LibYear.Lib.Tests.FileTypes
         {
             //arrange
             const string filename = "FileTypes\\packages.config";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var packagesConfigStream = new PackagesConfigStream(stream);
@@ -50,7 +46,7 @@ namespace LibYear.Lib.Tests.FileTypes
         {
             //arrange
             const string filename = "FileTypes\\packages.config";
-            using (var stream = LoadStreamFromFile(filename))
+            using (var stream = File.OpenRead(filename))
             {
                 //act
                 var packagesConfigStream = new PackagesConfigStream(stream);

--- a/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
+++ b/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
@@ -13,9 +13,6 @@
     <Content Include="FileTypes\packages.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="FileTypes\project.csproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Hey Steve,

This PR introduces a new `XmlProject` base type from which `XmlProjectFile` now inherits from. It consumes `streams` at a base level (so would be easy enough for people to build string/byte or other implementations - but I've left those out for now).

I've also introduced `CsProjStream` and `PackagesConfigStream` as `IProjectFile`'s which consumers can use. Not sure how I feel about having discreet types for these.

Few challenges, considering I didn't want to break the signature of the existing `XmlProjectFile`.

I didn't implement this for `project.json` given that it's EOL.
