### PR TITLE
Add Support for Directory.Build.[props/targets] files

### DIFF
--- a/src/LibYear.Lib/FileTypes/CsProjFile.cs
+++ b/src/LibYear.Lib/FileTypes/CsProjFile.cs
@@ -1,9 +1,9 @@
 namespace LibYear.Lib.FileTypes
 {
-  public class CsProjFile : XmlProjectFile
-  {
-    public CsProjFile(string filename) : base(filename, "PackageReference", new string[] { "Include", "Update" }, "Version")
+    public class CsProjFile : XmlProjectFile
     {
+        public CsProjFile(string filename) : base(filename, "PackageReference", new string[] { "Include", "Update" }, "Version")
+        {
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/FileTypes/CsProjFile.cs
+++ b/src/LibYear.Lib/FileTypes/CsProjFile.cs
@@ -1,9 +1,9 @@
 namespace LibYear.Lib.FileTypes
 {
-    public class CsProjFile : XmlProjectFile
+  public class CsProjFile : XmlProjectFile
+  {
+    public CsProjFile(string filename) : base(filename, "PackageReference", new string[] { "Include", "Update" }, "Version")
     {
-        public CsProjFile(string filename) : base(filename, "PackageReference", "Include", "Version")
-        {
-        }
     }
+  }
 }

--- a/src/LibYear.Lib/FileTypes/CsProjStream.cs
+++ b/src/LibYear.Lib/FileTypes/CsProjStream.cs
@@ -2,10 +2,10 @@
 
 namespace LibYear.Lib.FileTypes
 {
-    public class CsProjStream : XmlProject
+  public class CsProjStream : XmlProject
+  {
+    public CsProjStream(Stream fileStream) : base(fileStream, "PackageReference", new string[] { "Include", "Update" }, "Version")
     {
-        public CsProjStream(Stream fileStream) : base(fileStream, "PackageReference", "Include", "Version")
-        {
-        }
     }
+  }
 }

--- a/src/LibYear.Lib/FileTypes/CsProjStream.cs
+++ b/src/LibYear.Lib/FileTypes/CsProjStream.cs
@@ -2,10 +2,10 @@
 
 namespace LibYear.Lib.FileTypes
 {
-  public class CsProjStream : XmlProject
-  {
-    public CsProjStream(Stream fileStream) : base(fileStream, "PackageReference", new string[] { "Include", "Update" }, "Version")
+    public class CsProjStream : XmlProject
     {
+        public CsProjStream(Stream fileStream) : base(fileStream, "PackageReference", new string[] { "Include", "Update" }, "Version")
+        {
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/FileTypes/PackagesConfigFile.cs
+++ b/src/LibYear.Lib/FileTypes/PackagesConfigFile.cs
@@ -1,9 +1,9 @@
 namespace LibYear.Lib.FileTypes
 {
-    public class PackagesConfigFile : XmlProjectFile
+  public class PackagesConfigFile : XmlProjectFile
+  {
+    public PackagesConfigFile(string filename) : base(filename, "package", new string[] { "id" }, "version")
     {
-        public PackagesConfigFile(string filename) : base(filename, "package", "id", "version")
-        {
-        }
     }
+  }
 }

--- a/src/LibYear.Lib/FileTypes/PackagesConfigFile.cs
+++ b/src/LibYear.Lib/FileTypes/PackagesConfigFile.cs
@@ -1,9 +1,9 @@
 namespace LibYear.Lib.FileTypes
 {
-  public class PackagesConfigFile : XmlProjectFile
-  {
-    public PackagesConfigFile(string filename) : base(filename, "package", new string[] { "id" }, "version")
+    public class PackagesConfigFile : XmlProjectFile
     {
+        public PackagesConfigFile(string filename) : base(filename, "package", new string[] { "id" }, "version")
+        {
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
+++ b/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
@@ -2,10 +2,10 @@
 
 namespace LibYear.Lib.FileTypes
 {
-  public class PackagesConfigStream : XmlProject
-  {
-    public PackagesConfigStream(Stream fileStream) : base(fileStream, "package", new string[] { "id" }, "version")
+    public class PackagesConfigStream : XmlProject
     {
+        public PackagesConfigStream(Stream fileStream) : base(fileStream, "package", new string[] { "id" }, "version")
+        {
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
+++ b/src/LibYear.Lib/FileTypes/PackagesConfigStream.cs
@@ -2,10 +2,10 @@
 
 namespace LibYear.Lib.FileTypes
 {
-    public class PackagesConfigStream : XmlProject
+  public class PackagesConfigStream : XmlProject
+  {
+    public PackagesConfigStream(Stream fileStream) : base(fileStream, "package", new string[] { "id" }, "version")
     {
-        public PackagesConfigStream(Stream fileStream) : base(fileStream, "package", "id", "version")
-        {
-        }
     }
+  }
 }

--- a/src/LibYear.Lib/FileTypes/XmlProject.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProject.cs
@@ -6,41 +6,37 @@ using NuGet.Versioning;
 
 namespace LibYear.Lib.FileTypes
 {
-  public abstract class XmlProject : IHavePackages
-  {
-    protected readonly XDocument _xmlContents;
-    protected readonly Stream _xmlStream;
-    public IDictionary<string, SemanticVersion> Packages { get; }
-
-    protected XmlProject(Stream fileStream, string elementName, string[] packageAttributeNames, string versionAttributeName)
+    public abstract class XmlProject : IHavePackages
     {
-      _xmlStream = fileStream;
-      _xmlContents = XDocument.Load(fileStream);
+        protected readonly XDocument _xmlContents;
+        protected readonly Stream _xmlStream;
+        public IDictionary<string, SemanticVersion> Packages { get; }
 
-      Packages = _xmlContents.Descendants(elementName)
-        .ToDictionary(d =>
+        protected XmlProject(Stream fileStream, string elementName, string[] packageAttributeNames, string versionAttributeName)
         {
-          foreach (var packageAttributeName in packageAttributeNames)
-          {
-            var result = d.Attribute(packageAttributeName)?.Value ?? d.Element(packageAttributeName)?.Value;
-            if (result != null)
-            {
-              return result;
-            }
-          }
-          return null;
-        }, d =>
-        {
-          foreach (var packageAttributeName in packageAttributeNames)
-          {
-            var result = SemanticVersion.Parse(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value);
-            if (result != null)
-            {
-              return result;
-            }
-          }
-          return null;
-        });
+            _xmlStream = fileStream;
+            _xmlContents = XDocument.Load(fileStream);
+
+            Packages = _xmlContents.Descendants(elementName)
+                .ToDictionary(d =>
+                {
+                    foreach (var packageAttributeName in packageAttributeNames)
+                    {
+                        var result = d.Attribute(packageAttributeName)?.Value ?? d.Element(packageAttributeName)?.Value;
+                        if (result != null)
+                            return result;
+                    }
+                    return null;
+                    }, d =>
+                    {
+                    foreach (var packageAttributeName in packageAttributeNames)
+                    {
+                        var result = SemanticVersion.Parse(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value);
+                        if (result != null)
+                            return result;
+                    }
+                    return null;
+                });
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
@@ -4,51 +4,54 @@ using System.Linq;
 
 namespace LibYear.Lib.FileTypes
 {
-    public abstract class XmlProjectFile : XmlProject, IProjectFile
+  public abstract class XmlProjectFile : XmlProject, IProjectFile
+  {
+    private readonly string _elementName;
+    private readonly string[] _packageAttributeNames;
+    private readonly string _versionAttributeName;
+    public string FileName { get; }
+
+    protected XmlProjectFile(string filename, string elementName, string[] packageAttributeNames, string versionAttributeName)
+        : base(File.OpenRead(filename), elementName, packageAttributeNames, versionAttributeName)
     {
-        private readonly string _elementName;
-        private readonly string _packageAttributeName;
-        private readonly string _versionAttributeName;
-        public string FileName { get; }
+      FileName = filename;
 
-        protected XmlProjectFile(string filename, string elementName, string packageAttributeName, string versionAttributeName)
-            : base(File.OpenRead(filename), elementName, packageAttributeName, versionAttributeName)
-        {
-            FileName = filename;
+      _elementName = elementName;
+      _packageAttributeNames = packageAttributeNames;
+      _versionAttributeName = versionAttributeName;
 
-            _elementName = elementName;
-            _packageAttributeName = packageAttributeName;
-            _versionAttributeName = versionAttributeName;
-
-            _xmlStream.Dispose();
-        }
-
-        public void Update(IEnumerable<Result> results)
-        {
-            lock (_xmlContents)
-            {
-                foreach (var result in results)
-                {
-                    var elements = _xmlContents.Descendants(_elementName)
-                        .Where(d => (d.Attribute(_packageAttributeName)?.Value ?? d.Element(_packageAttributeName)?.Value) == result.Name
-                                 && (d.Attribute(_versionAttributeName)?.Value ?? d.Element(_versionAttributeName)?.Value) == result.Installed?.Version.ToString());
-
-                    foreach (var element in elements)
-                    {
-                        var attribute = element.Attribute(_versionAttributeName);
-                        if (attribute != null)
-                            attribute.Value = result.Latest.Version.ToString();
-                        else
-                        {
-                            var e = element.Element(_versionAttributeName);
-                            if (e != null)
-                                e.Value = result.Latest.Version.ToString();
-                        }
-                    }
-                }
-
-                File.WriteAllText(FileName, _xmlContents.ToString());
-            }
-        }
+      _xmlStream.Dispose();
     }
+
+    public void Update(IEnumerable<Result> results)
+    {
+      lock (_xmlContents)
+      {
+        foreach (var result in results)
+        {
+          var elements = _xmlContents.Descendants(_elementName)
+              .Where(d => _packageAttributeNames.Any(attributeName =>
+                (d.Attribute(attributeName)?.Value ?? d.Element(attributeName)?.Value) == result.Name
+                    && (d.Attribute(_versionAttributeName)?.Value ?? d.Element(_versionAttributeName)?.Value) == result.Installed?.Version.ToString()
+                )
+              );
+
+          foreach (var element in elements)
+          {
+            var attribute = element.Attribute(_versionAttributeName);
+            if (attribute != null)
+              attribute.Value = result.Latest.Version.ToString();
+            else
+            {
+              var e = element.Element(_versionAttributeName);
+              if (e != null)
+                e.Value = result.Latest.Version.ToString();
+            }
+          }
+        }
+
+        File.WriteAllText(FileName, _xmlContents.ToString());
+      }
+    }
+  }
 }

--- a/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
@@ -4,54 +4,54 @@ using System.Linq;
 
 namespace LibYear.Lib.FileTypes
 {
-  public abstract class XmlProjectFile : XmlProject, IProjectFile
-  {
-    private readonly string _elementName;
-    private readonly string[] _packageAttributeNames;
-    private readonly string _versionAttributeName;
-    public string FileName { get; }
-
-    protected XmlProjectFile(string filename, string elementName, string[] packageAttributeNames, string versionAttributeName)
-        : base(File.OpenRead(filename), elementName, packageAttributeNames, versionAttributeName)
+    public abstract class XmlProjectFile : XmlProject, IProjectFile
     {
-      FileName = filename;
+        private readonly string _elementName;
+        private readonly string[] _packageAttributeNames;
+        private readonly string _versionAttributeName;
+        public string FileName { get; }
 
-      _elementName = elementName;
-      _packageAttributeNames = packageAttributeNames;
-      _versionAttributeName = versionAttributeName;
-
-      _xmlStream.Dispose();
-    }
-
-    public void Update(IEnumerable<Result> results)
-    {
-      lock (_xmlContents)
-      {
-        foreach (var result in results)
+        protected XmlProjectFile(string filename, string elementName, string[] packageAttributeNames, string versionAttributeName)
+            : base(File.OpenRead(filename), elementName, packageAttributeNames, versionAttributeName)
         {
-          var elements = _xmlContents.Descendants(_elementName)
-              .Where(d => _packageAttributeNames.Any(attributeName =>
-                (d.Attribute(attributeName)?.Value ?? d.Element(attributeName)?.Value) == result.Name
-                    && (d.Attribute(_versionAttributeName)?.Value ?? d.Element(_versionAttributeName)?.Value) == result.Installed?.Version.ToString()
-                )
-              );
+            FileName = filename;
 
-          foreach (var element in elements)
-          {
-            var attribute = element.Attribute(_versionAttributeName);
-            if (attribute != null)
-              attribute.Value = result.Latest.Version.ToString();
-            else
-            {
-              var e = element.Element(_versionAttributeName);
-              if (e != null)
-                e.Value = result.Latest.Version.ToString();
-            }
-          }
+            _elementName = elementName;
+            _packageAttributeNames = packageAttributeNames;
+            _versionAttributeName = versionAttributeName;
+
+            _xmlStream.Dispose();
         }
 
-        File.WriteAllText(FileName, _xmlContents.ToString());
-      }
+        public void Update(IEnumerable<Result> results)
+        {
+            lock (_xmlContents)
+            {
+                foreach (var result in results)
+                {
+                    var elements = _xmlContents.Descendants(_elementName)
+                        .Where(d => _packageAttributeNames.Any(attributeName =>
+                            (d.Attribute(attributeName)?.Value ?? d.Element(attributeName)?.Value) == result.Name
+                                && (d.Attribute(_versionAttributeName)?.Value ?? d.Element(_versionAttributeName)?.Value) == result.Installed?.Version.ToString()
+                            )
+                        );
+
+                    foreach (var element in elements)
+                    {
+                        var attribute = element.Attribute(_versionAttributeName);
+                        if (attribute != null)
+                            attribute.Value = result.Latest.Version.ToString();
+                        else
+                        {
+                            var e = element.Element(_versionAttributeName);
+                            if (e != null)
+                                e.Value = result.Latest.Version.ToString();
+                        }
+                    }
+                }
+
+                File.WriteAllText(FileName, _xmlContents.ToString());
+            }
+        }
     }
-  }
 }

--- a/src/LibYear.Lib/ProjectFileManager.cs
+++ b/src/LibYear.Lib/ProjectFileManager.cs
@@ -39,6 +39,8 @@ namespace LibYear.Lib
         public IList<IProjectFile> FindProjects(DirectoryInfo dir, SearchOption searchMode)
         {
             return dir.EnumerateFiles("*.csproj", searchMode).Select<FileInfo, IProjectFile>(f => new CsProjFile(f.FullName))
+                .Union(dir.EnumerateFiles("Directory.build.props", searchMode).Select<FileInfo, IProjectFile>(f => new CsProjFile(f.FullName)))
+                .Union(dir.EnumerateFiles("Directory.build.targets", searchMode).Select<FileInfo, IProjectFile>(f => new CsProjFile(f.FullName)))
                 .Union(dir.EnumerateFiles("project.json", searchMode).Select<FileInfo, IProjectFile>(f => new ProjectJsonFile(f.FullName)))
                 .Union(dir.EnumerateFiles("packages.config", searchMode).Select<FileInfo, IProjectFile>(f => new PackagesConfigFile(f.FullName)))
                 .ToList();

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
@@ -25,5 +25,39 @@ namespace LibYear.Lib.Tests.FileTypes
                 Assert.Equal("test5", csprojStream.Packages.Skip(4).First().Key);
             }
         }
+
+        [Fact]
+        public void CanLoadPropsAsCsProjStream()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.props";
+            using (var stream = File.OpenRead(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
+
+                //assert
+                Assert.Equal("test1", csprojStream.Packages.First().Key);
+                Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
+                Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
+            }
+        }
+
+        [Fact]
+        public void CanLoadTargetsAsCsProjStream()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.targets";
+            using (var stream = File.OpenRead(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
+
+                //assert
+                Assert.Equal("test1", csprojStream.Packages.First().Key);
+                Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
+                Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
+            }
+        }
     }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
@@ -5,25 +5,25 @@ using Xunit;
 
 namespace LibYear.Lib.Tests.FileTypes
 {
-  public class CsProjProjectStreamTests
-  {
-    [Fact]
-    public void CanLoadCsProjStream()
+    public class CsProjProjectStreamTests
     {
-      //arrange
-      const string filename = "FileTypes\\project.csproj";
-      using (var stream = File.OpenRead(filename))
-      {
-        //act
-        var csprojStream = new CsProjStream(stream);
+        [Fact]
+        public void CanLoadCsProjStream()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
+            using (var stream = File.OpenRead(filename))
+            {
+                //act
+                var csprojStream = new CsProjStream(stream);
 
-        //assert
-        Assert.Equal("test1", csprojStream.Packages.First().Key);
-        Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
-        Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
-        Assert.Equal("test4", csprojStream.Packages.Skip(3).First().Key);
-        Assert.Equal("test5", csprojStream.Packages.Skip(4).First().Key);
-      }
+                //assert
+                Assert.Equal("test1", csprojStream.Packages.First().Key);
+                Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
+                Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
+                Assert.Equal("test4", csprojStream.Packages.Skip(3).First().Key);
+                Assert.Equal("test5", csprojStream.Packages.Skip(4).First().Key);
+            }
+        }
     }
-  }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjProjectStreamTests.cs
@@ -5,23 +5,25 @@ using Xunit;
 
 namespace LibYear.Lib.Tests.FileTypes
 {
-    public class CsProjProjectStreamTests
+  public class CsProjProjectStreamTests
+  {
+    [Fact]
+    public void CanLoadCsProjStream()
     {
-        [Fact]
-        public void CanLoadCsProjStream()
-        {
-            //arrange
-            const string filename = "FileTypes\\project.csproj";
-            using (var stream = File.OpenRead(filename))
-            {
-                //act
-                var csprojStream = new CsProjStream(stream);
+      //arrange
+      const string filename = "FileTypes\\project.csproj";
+      using (var stream = File.OpenRead(filename))
+      {
+        //act
+        var csprojStream = new CsProjStream(stream);
 
-                //assert
-                Assert.Equal("test1", csprojStream.Packages.First().Key);
-                Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
-                Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
-            }
-        }
+        //assert
+        Assert.Equal("test1", csprojStream.Packages.First().Key);
+        Assert.Equal("test2", csprojStream.Packages.Skip(1).First().Key);
+        Assert.Equal("test3", csprojStream.Packages.Skip(2).First().Key);
+        Assert.Equal("test4", csprojStream.Packages.Skip(3).First().Key);
+        Assert.Equal("test5", csprojStream.Packages.Skip(4).First().Key);
+      }
     }
+  }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
@@ -7,32 +7,32 @@ using Xunit;
 
 namespace LibYear.Lib.Tests.FileTypes
 {
-  public class CsProjTests
-  {
-    [Fact]
-    public void CanLoadCsProjFile()
+    public class CsProjTests
     {
-      //arrange
-      const string filename = "FileTypes\\project.csproj";
+        [Fact]
+        public void CanLoadCsProjFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
 
-      //act
-      var file = new CsProjFile(filename);
+            //act
+            var file = new CsProjFile(filename);
 
-      //assert
-      Assert.Equal("test1", file.Packages.First().Key);
-      Assert.Equal("test2", file.Packages.Skip(1).First().Key);
-      Assert.Equal("test3", file.Packages.Skip(2).First().Key);
-      Assert.Equal("test4", file.Packages.Skip(3).First().Key);
-      Assert.Equal("test5", file.Packages.Skip(4).First().Key);
-    }
+            //assert
+            Assert.Equal("test1", file.Packages.First().Key);
+            Assert.Equal("test2", file.Packages.Skip(1).First().Key);
+            Assert.Equal("test3", file.Packages.Skip(2).First().Key);
+            Assert.Equal("test4", file.Packages.Skip(3).First().Key);
+            Assert.Equal("test5", file.Packages.Skip(4).First().Key);
+        }
 
-    [Fact]
-    public void CanUpdateCsProjFile()
-    {
-      //arrange
-      const string filename = "FileTypes\\project.csproj";
-      var file = new CsProjFile(filename);
-      var results = new List<Result>
+        [Fact]
+        public void CanUpdateCsProjFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\project.csproj";
+            var file = new CsProjFile(filename);
+            var results = new List<Result>
             {
                 new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
                 new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
@@ -41,16 +41,16 @@ namespace LibYear.Lib.Tests.FileTypes
                 new Result("test5", new VersionInfo(new SemanticVersion(0, 5, 0), DateTime.Today), new VersionInfo(new SemanticVersion(5, 6, 7), DateTime.Today))
             };
 
-      //act
-      file.Update(results);
+            //act
+            file.Update(results);
 
-      //assert
-      var newFile = new CsProjFile(filename);
-      Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
-      Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
-      Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
-      Assert.Equal("4.5.6", newFile.Packages.Skip(3).First().Value.ToString());
-      Assert.Equal("5.6.7", newFile.Packages.Skip(4).First().Value.ToString());
+            //assert
+            var newFile = new CsProjFile(filename);
+            Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
+            Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
+            Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
+            Assert.Equal("4.5.6", newFile.Packages.Skip(3).First().Value.ToString());
+            Assert.Equal("5.6.7", newFile.Packages.Skip(4).First().Value.ToString());
+        }
     }
-  }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
@@ -7,44 +7,50 @@ using Xunit;
 
 namespace LibYear.Lib.Tests.FileTypes
 {
-    public class CsProjTests
+  public class CsProjTests
+  {
+    [Fact]
+    public void CanLoadCsProjFile()
     {
-        [Fact]
-        public void CanLoadCsProjFile()
-        {
-            //arrange
-            const string filename = "FileTypes\\project.csproj";
+      //arrange
+      const string filename = "FileTypes\\project.csproj";
 
-            //act
-            var file = new CsProjFile(filename);
+      //act
+      var file = new CsProjFile(filename);
 
-            //assert
-            Assert.Equal("test1", file.Packages.First().Key);
-            Assert.Equal("test2", file.Packages.Skip(1).First().Key);
-            Assert.Equal("test3", file.Packages.Skip(2).First().Key);
-        }
+      //assert
+      Assert.Equal("test1", file.Packages.First().Key);
+      Assert.Equal("test2", file.Packages.Skip(1).First().Key);
+      Assert.Equal("test3", file.Packages.Skip(2).First().Key);
+      Assert.Equal("test4", file.Packages.Skip(3).First().Key);
+      Assert.Equal("test5", file.Packages.Skip(4).First().Key);
+    }
 
-        [Fact]
-        public void CanUpdateCsProjFile()
-        {
-            //arrange
-            const string filename = "FileTypes\\project.csproj";
-            var file = new CsProjFile(filename);
-            var results = new List<Result>
+    [Fact]
+    public void CanUpdateCsProjFile()
+    {
+      //arrange
+      const string filename = "FileTypes\\project.csproj";
+      var file = new CsProjFile(filename);
+      var results = new List<Result>
             {
                 new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
                 new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today)),
+                new Result("test4", new VersionInfo(new SemanticVersion(0, 4, 0), DateTime.Today), new VersionInfo(new SemanticVersion(4, 5, 6), DateTime.Today)),
+                new Result("test5", new VersionInfo(new SemanticVersion(0, 5, 0), DateTime.Today), new VersionInfo(new SemanticVersion(5, 6, 7), DateTime.Today))
             };
 
-            //act
-            file.Update(results);
+      //act
+      file.Update(results);
 
-            //assert
-            var newFile = new CsProjFile(filename);
-            Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
-            Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
-            Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
-        }
+      //assert
+      var newFile = new CsProjFile(filename);
+      Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
+      Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
+      Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
+      Assert.Equal("4.5.6", newFile.Packages.Skip(3).First().Value.ToString());
+      Assert.Equal("5.6.7", newFile.Packages.Skip(4).First().Value.ToString());
     }
+  }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjTests.cs
@@ -27,6 +27,36 @@ namespace LibYear.Lib.Tests.FileTypes
         }
 
         [Fact]
+        public void CanLoadPropsAsProjFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.props";
+
+            //act
+            var file = new CsProjFile(filename);
+
+            //assert
+            Assert.Equal("test1", file.Packages.First().Key);
+            Assert.Equal("test2", file.Packages.Skip(1).First().Key);
+            Assert.Equal("test3", file.Packages.Skip(2).First().Key);
+        }
+
+        [Fact]
+        public void CanLoadTargetsAsProjFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.targets";
+
+            //act
+            var file = new CsProjFile(filename);
+
+            //assert
+            Assert.Equal("test1", file.Packages.First().Key);
+            Assert.Equal("test2", file.Packages.Skip(1).First().Key);
+            Assert.Equal("test3", file.Packages.Skip(2).First().Key);
+        }
+
+        [Fact]
         public void CanUpdateCsProjFile()
         {
             //arrange
@@ -51,6 +81,51 @@ namespace LibYear.Lib.Tests.FileTypes
             Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
             Assert.Equal("4.5.6", newFile.Packages.Skip(3).First().Value.ToString());
             Assert.Equal("5.6.7", newFile.Packages.Skip(4).First().Value.ToString());
+        }
+        [Fact]
+        public void CanUpdatePropsFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.props";
+            var file = new CsProjFile(filename);
+            var results = new List<Result>
+                {
+                    new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
+                    new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
+                    new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                };
+
+            //act
+            file.Update(results);
+
+            //assert
+            var newFile = new CsProjFile(filename);
+            Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
+            Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
+            Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
+        }
+
+        [Fact]
+        public void CanUpdateTargetsFile()
+        {
+            //arrange
+            const string filename = "FileTypes\\Directory.Build.targets";
+            var file = new CsProjFile(filename);
+            var results = new List<Result>
+                {
+                    new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
+                    new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
+                    new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                };
+
+            //act
+            file.Update(results);
+                   
+            //assert
+            var newFile = new CsProjFile(filename);
+            Assert.Equal("1.2.3", newFile.Packages.First().Value.ToString());
+            Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value.ToString());
+            Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value.ToString());
         }
     }
 }

--- a/test/LibYear.Lib.Tests/FileTypes/Directory.Build.props
+++ b/test/LibYear.Lib.Tests/FileTypes/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Update="test1" Version="0.1.0" />
+    <PackageReference Update="test2" Version="0.2.0" />
+    <PackageReference>
+      <Update>test3</Update>
+      <Version>0.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project> 

--- a/test/LibYear.Lib.Tests/FileTypes/Directory.Build.targets
+++ b/test/LibYear.Lib.Tests/FileTypes/Directory.Build.targets
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Update="test1" Version="0.1.0" />
+    <PackageReference Update="test2" Version="0.2.0" />
+    <PackageReference>
+      <Update>test3</Update>
+      <Version>0.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project> 

--- a/test/LibYear.Lib.Tests/FileTypes/project.csproj
+++ b/test/LibYear.Lib.Tests/FileTypes/project.csproj
@@ -8,9 +8,14 @@
   <ItemGroup>
     <PackageReference Include="test1" Version="0.1.0" />
     <PackageReference Include="test2" Version="0.2.0" />
+    <PackageReference Update="test3" Version="0.3.0" />
     <PackageReference>
-      <Include>test3</Include>
-      <Version>0.3.0</Version>
+      <Include>test4</Include>
+      <Version>0.4.0</Version>
+    </PackageReference>
+    <PackageReference>
+      <Include>test5</Include>
+      <Version>0.5.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/test/LibYear.Lib.Tests/FileTypes/project.csproj
+++ b/test/LibYear.Lib.Tests/FileTypes/project.csproj
@@ -14,7 +14,7 @@
       <Version>0.4.0</Version>
     </PackageReference>
     <PackageReference>
-      <Include>test5</Include>
+      <Update>test5</Update>
       <Version>0.5.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
+++ b/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
@@ -19,6 +19,12 @@
     <Content Include="FileTypes\project.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="FileTypes\Directory.Build.props">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="FileTypes\Directory.Build.targets">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Overview

As outlined in [this article](https://www.strathweb.com/2018/07/solution-wide-nuget-package-version-handling-with-msbuild-15/), the Directory.Build.targets and Directory.Build.props files can also contain this version information. It would be nice to include support in libyear.

# Resources
 [More information from MS here.](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019)