### PR TITLE
Account for Packages with no Version

### DIFF
--- a/src/LibYear.Lib/FileTypes/XmlProject.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProject.cs
@@ -1,25 +1,39 @@
-﻿using System.Collections.Generic;
+﻿using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Xml.Linq;
-using NuGet.Versioning;
 
 namespace LibYear.Lib.FileTypes
 {
-    public abstract class XmlProject : IHavePackages
-    {
-        protected readonly XDocument _xmlContents;
-        protected readonly Stream _xmlStream;
-        public IDictionary<string, SemanticVersion> Packages { get; }
+	public abstract class XmlProject : IHavePackages
+	{
+		protected readonly XDocument _xmlContents;
+		protected readonly Stream _xmlStream;
+		public IDictionary<string, SemanticVersion> Packages { get; } = new Dictionary<string, SemanticVersion>();
 
-        protected XmlProject(Stream fileStream, string elementName, string packageAttributeName, string versionAttributeName)
-        {
-            _xmlStream = fileStream;
-            _xmlContents = XDocument.Load(fileStream);
+		protected XmlProject(Stream fileStream, string elementName, string packageAttributeName, string versionAttributeName)
+		{
+			_xmlStream = fileStream;
+			_xmlContents = XDocument.Load(fileStream);
 
-            Packages = _xmlContents.Descendants(elementName)
-                .ToDictionary(d => d.Attribute(packageAttributeName)?.Value ?? d.Element(packageAttributeName)?.Value,
-                    d => SemanticVersion.Parse(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value));
-        }
-    }
+			foreach (var reference in _xmlContents.Descendants(elementName))
+			{
+				var name = reference.Attribute(packageAttributeName)?.Value ?? reference.Element(packageAttributeName)?.Value;
+				var version = reference.Attribute(versionAttributeName)?.Value ?? reference.Element(versionAttributeName)?.Value;
+
+				if (!string.IsNullOrEmpty(name) && SemanticVersion.TryParse(version, out var semver))
+				{
+					Packages.Add(name, semver);
+				}
+				else if (System.Diagnostics.Debugger.IsAttached)
+				{
+					if (string.IsNullOrEmpty(name))
+						Console.Error.WriteLine($"Package Reference with no name!");
+					else
+						Console.Error.WriteLine($"Reference \"{name}\" has missing or invalid version: \"{version ?? "null"}\".");
+				}
+			}
+		}
+	}
 }

--- a/test/LibYear.Lib.Tests/FileTypes/project.csproj
+++ b/test/LibYear.Lib.Tests/FileTypes/project.csproj
@@ -13,4 +13,7 @@
       <Version>0.3.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
As you can see by this [StackOverflow](https://stackoverflow.com/questions/55161834/microsoft-aspnetcore-app-versioning-should-it-be-referenced-in-non-asp-net-c) conversation, there are situations where there will be `<PackageReference />` elements with _no_ version attribute.

Currently, this causes an unhandled exception and prevents any useful results from the tool. I added a simple check for valid name/version attributes and just ignore any packages that don't have values.