### PR TITLE
Update Version Handling

### DIFF
--- a/src/LibYear.Lib/FileTypes/IProjectFile.cs
+++ b/src/LibYear.Lib/FileTypes/IProjectFile.cs
@@ -6,7 +6,7 @@ namespace LibYear.Lib.FileTypes
     public interface IProjectFile
     {
         string FileName { get; }
-        IDictionary<string, SemanticVersion> Packages { get; }
+        IDictionary<string, NuGetVersion> Packages { get; }
         void Update(IEnumerable<Result> results);
 
     }

--- a/src/LibYear.Lib/FileTypes/ProjectJsonFile.cs
+++ b/src/LibYear.Lib/FileTypes/ProjectJsonFile.cs
@@ -10,13 +10,13 @@ namespace LibYear.Lib.FileTypes
     {
         private string _fileContents;
         public string FileName { get; }
-        public IDictionary<string, SemanticVersion> Packages { get; }
+        public IDictionary<string, NuGetVersion> Packages { get; }
 
         public ProjectJsonFile(string filename)
         {
             FileName = filename;
             _fileContents = File.ReadAllText(FileName);
-            Packages = GetDependencies().ToDictionary(p => ((JProperty)p).Name.ToString(), p => SemanticVersion.Parse(((JProperty)p).Value.ToString()));
+            Packages = GetDependencies().ToDictionary(p => ((JProperty)p).Name.ToString(), p => NuGetVersion.Parse(((JProperty)p).Value.ToString()));
         }
 
         private IEnumerable<JToken> GetDependencies()

--- a/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
+++ b/src/LibYear.Lib/FileTypes/XmlProjectFile.cs
@@ -14,7 +14,7 @@ namespace LibYear.Lib.FileTypes
         private readonly string _versionAttributeName;
 
         public string FileName { get; }
-        public IDictionary<string, SemanticVersion> Packages { get; }
+        public IDictionary<string, NuGetVersion> Packages { get; }
 
         protected XmlProjectFile(string filename, string elementName, string[] packageAttributeNames, string versionAttributeName)
         {
@@ -29,7 +29,7 @@ namespace LibYear.Lib.FileTypes
             Packages = _xmlContents.Descendants(elementName).ToDictionary(
                 d => packageAttributeNames.Select(p => d.Attribute(p)?.Value ?? d.Element(p)?.Value).FirstOrDefault(v => v != null),
                 d => !string.IsNullOrEmpty(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value)
-                    ? SemanticVersion.Parse(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value)
+                    ? NuGetVersion.Parse(d.Attribute(versionAttributeName)?.Value ?? d.Element(versionAttributeName)?.Value)
                     : null
             );
         }

--- a/src/LibYear.Lib/LibYear.Lib.csproj
+++ b/src/LibYear.Lib/LibYear.Lib.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/LibYear.Lib/PackageVersionChecker.cs
+++ b/src/LibYear.Lib/PackageVersionChecker.cs
@@ -40,7 +40,7 @@ namespace LibYear.Lib
 
         public async Task<IList<VersionInfo>> GetVersions(string packageName)
         {
-            var metadata = _metadataResource.GetMetadataAsync(packageName, true, true, new NullLogger(), CancellationToken.None);
+            var metadata = _metadataResource.GetMetadataAsync(packageName, true, true, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
             return (await metadata).Select(m => new VersionInfo(m)).ToList();
         }
     }

--- a/src/LibYear.Lib/PackageVersionChecker.cs
+++ b/src/LibYear.Lib/PackageVersionChecker.cs
@@ -30,7 +30,7 @@ namespace LibYear.Lib
             return tasks.Select(t => t.Result);
         }
 
-        public async Task<Result> GetResultTask(string packageName, SemanticVersion installed)
+        public async Task<Result> GetResultTask(string packageName, NuGetVersion installed)
         {
             var versions = _versionCache.ContainsKey(packageName) ? _versionCache[packageName] : _versionCache[packageName] = await GetVersions(packageName);
             var current = versions.FirstOrDefault(v => v.Version == installed);

--- a/src/LibYear.Lib/VersionInfo.cs
+++ b/src/LibYear.Lib/VersionInfo.cs
@@ -6,14 +6,14 @@ namespace LibYear.Lib
 {
     public class VersionInfo
     {
-        public SemanticVersion Version { get; }
+        public NuGetVersion Version { get; }
         public DateTime Released { get; }
 
         public VersionInfo(IPackageSearchMetadata metadata) : this(metadata.Identity.Version, metadata.Published.GetValueOrDefault().Date)
         {
         }
 
-        public VersionInfo(SemanticVersion version, DateTime released)
+        public VersionInfo(NuGetVersion version, DateTime released)
         {
             Version = version;
             Released = released;

--- a/src/LibYear/LibYear.App.csproj
+++ b/src/LibYear/LibYear.App.csproj
@@ -18,7 +18,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="template\.template.config\template.json" />

--- a/test/LibYear.Lib.Tests/FileTypes/CsProjFileTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/CsProjFileTests.cs
@@ -36,11 +36,11 @@ namespace LibYear.Lib.Tests.FileTypes
             var file = new CsProjFile(filename);
             var results = new List<Result>
             {
-                new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
-                new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today)),
-                new Result("test4", new VersionInfo(new SemanticVersion(0, 4, 0), DateTime.Today), new VersionInfo(new SemanticVersion(4, 5, 6), DateTime.Today)),
-                new Result("test5", new VersionInfo(new SemanticVersion(0, 5, 0), DateTime.Today), new VersionInfo(new SemanticVersion(5, 6, 7), DateTime.Today)),
+                new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0, 1), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
+                new Result("test2", new VersionInfo(new NuGetVersion(0, 2, 0), DateTime.Today), new VersionInfo(new NuGetVersion(2, 3, 4), DateTime.Today)),
+                new Result("test3", new VersionInfo(new NuGetVersion(0, 3, 0), DateTime.Today), new VersionInfo(new NuGetVersion(3, 4, 5), DateTime.Today)),
+                new Result("test4", new VersionInfo(new NuGetVersion(0, 4, 0), DateTime.Today), new VersionInfo(new NuGetVersion(4, 5, 6), DateTime.Today)),
+                new Result("test5", new VersionInfo(new NuGetVersion(0, 5, 0), DateTime.Today), new VersionInfo(new NuGetVersion(5, 6, 7), DateTime.Today)),
             };
 
             //act

--- a/test/LibYear.Lib.Tests/FileTypes/DirectoryBuildPropsTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/DirectoryBuildPropsTests.cs
@@ -33,9 +33,9 @@ namespace LibYear.Lib.Tests.FileTypes
             var file = new DirectoryBuildPropsFile(filename);
             var results = new List<Result>
             {
-                new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
-                new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
+                new Result("test2", new VersionInfo(new NuGetVersion(0, 2, 0), DateTime.Today), new VersionInfo(new NuGetVersion(2, 3, 4), DateTime.Today)),
+                new Result("test3", new VersionInfo(new NuGetVersion(0, 3, 0), DateTime.Today), new VersionInfo(new NuGetVersion(3, 4, 5), DateTime.Today))
             };
 
             //act

--- a/test/LibYear.Lib.Tests/FileTypes/DirectoryBuildTargetsTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/DirectoryBuildTargetsTests.cs
@@ -33,9 +33,9 @@ namespace LibYear.Lib.Tests.FileTypes
             var file = new DirectoryBuildTargetsFile(filename);
             var results = new List<Result>
             {
-                new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
-                new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
+                new Result("test2", new VersionInfo(new NuGetVersion(0, 2, 0), DateTime.Today), new VersionInfo(new NuGetVersion(2, 3, 4), DateTime.Today)),
+                new Result("test3", new VersionInfo(new NuGetVersion(0, 3, 0), DateTime.Today), new VersionInfo(new NuGetVersion(3, 4, 5), DateTime.Today))
             };
 
             //act

--- a/test/LibYear.Lib.Tests/FileTypes/PackagesConfigFileTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/PackagesConfigFileTests.cs
@@ -33,9 +33,9 @@ namespace LibYear.Lib.Tests.FileTypes
             var file = new PackagesConfigFile(filename);
             var results = new List<Result>
             {
-                new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
-                new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
+                new Result("test2", new VersionInfo(new NuGetVersion(0, 2, 0), DateTime.Today), new VersionInfo(new NuGetVersion(2, 3, 4), DateTime.Today)),
+                new Result("test3", new VersionInfo(new NuGetVersion(0, 3, 0), DateTime.Today), new VersionInfo(new NuGetVersion(3, 4, 5), DateTime.Today))
             };
 
             //act

--- a/test/LibYear.Lib.Tests/FileTypes/ProjectJsonFileTests.cs
+++ b/test/LibYear.Lib.Tests/FileTypes/ProjectJsonFileTests.cs
@@ -33,9 +33,9 @@ namespace LibYear.Lib.Tests.FileTypes
             var file = new ProjectJsonFile(filename);
             var results = new List<Result>
             {
-                new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
-                new Result("test2", new VersionInfo(new SemanticVersion(0, 2, 0), DateTime.Today), new VersionInfo(new SemanticVersion(2, 3, 4), DateTime.Today)),
-                new Result("test3", new VersionInfo(new SemanticVersion(0, 3, 0), DateTime.Today), new VersionInfo(new SemanticVersion(3, 4, 5), DateTime.Today))
+                new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0, 1), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
+                new Result("test2", new VersionInfo(new NuGetVersion(0, 2, 0), DateTime.Today), new VersionInfo(new NuGetVersion(2, 3, 4), DateTime.Today)),
+                new Result("test3", new VersionInfo(new NuGetVersion(0, 3, 0), DateTime.Today), new VersionInfo(new NuGetVersion(3, 4, 5), DateTime.Today))
             };
 
             //act

--- a/test/LibYear.Lib.Tests/FileTypes/project.csproj
+++ b/test/LibYear.Lib.Tests/FileTypes/project.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="test1" Version="0.1.0" />
+    <PackageReference Include="test1" Version="0.1.0.1" />
     <PackageReference Include="test2" Version="0.2.0" />
     <PackageReference Update="test3" Version="0.3.0" />
     <PackageReference>

--- a/test/LibYear.Lib.Tests/FileTypes/project.json
+++ b/test/LibYear.Lib.Tests/FileTypes/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "test1": "0.1.0",
+    "test1": "0.1.0.1",
     "test2": "0.2.0",
     "test3": { "version": "0.3.0" }
   }

--- a/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
+++ b/test/LibYear.Lib.Tests/LibYear.Lib.Tests.csproj
@@ -30,7 +30,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.2.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/LibYear.Lib.Tests/PackageVersionCheckerTests.cs
+++ b/test/LibYear.Lib.Tests/PackageVersionCheckerTests.cs
@@ -41,13 +41,13 @@ namespace LibYear.Lib.Tests
             metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
-            var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
-            var v2 = new VersionInfo(new SemanticVersion(2, 3, 4), new DateTime(2016, 1, 1));
+            var v1 = new VersionInfo(new NuGetVersion(1, 2, 3), new DateTime(2015, 1, 1));
+            var v2 = new VersionInfo(new NuGetVersion(2, 3, 4), new DateTime(2016, 1, 1));
             var versionCache = new Dictionary<string, IList<VersionInfo>> { { "test", new List<VersionInfo> { v1, v2 } } };
             var checker = new PackageVersionChecker(metadataResource, versionCache);
 
             //act
-            var result = await checker.GetResultTask("test", new SemanticVersion(1, 2, 3));
+            var result = await checker.GetResultTask("test", new NuGetVersion(1, 2, 3));
 
             //assert
             var latest = result.Latest.Version.ToString();
@@ -63,13 +63,13 @@ namespace LibYear.Lib.Tests
             metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
-            var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
-            var v2 = new VersionInfo(SemanticVersion.Parse("2.3.4-beta-1"), new DateTime(2016, 1, 1));
+            var v1 = new VersionInfo(new NuGetVersion(1, 2, 3), new DateTime(2015, 1, 1));
+            var v2 = new VersionInfo(NuGetVersion.Parse("2.3.4-beta-1"), new DateTime(2016, 1, 1));
             var versionCache = new Dictionary<string, IList<VersionInfo>> { { "test", new List<VersionInfo> { v1, v2 } } };
             var checker = new PackageVersionChecker(metadataResource, versionCache);
 
             //act
-            var result = await checker.GetResultTask("test", new SemanticVersion(1, 2, 3));
+            var result = await checker.GetResultTask("test", new NuGetVersion(1, 2, 3));
 
             //assert
             var latest = result.Latest.Version.ToString();
@@ -85,13 +85,13 @@ namespace LibYear.Lib.Tests
             metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
-            var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
-            var v2 = new VersionInfo(new SemanticVersion(2, 3, 4), new DateTime(1900, 1, 1));
+            var v1 = new VersionInfo(new NuGetVersion(1, 2, 3), new DateTime(2015, 1, 1));
+            var v2 = new VersionInfo(new NuGetVersion(2, 3, 4), new DateTime(1900, 1, 1));
             var versionCache = new Dictionary<string, IList<VersionInfo>> { { "test", new List<VersionInfo> { v1, v2 } } };
             var checker = new PackageVersionChecker(metadataResource, versionCache);
 
             //act
-            var result = await checker.GetResultTask("test", new SemanticVersion(1, 2, 3));
+            var result = await checker.GetResultTask("test", new NuGetVersion(1, 2, 3));
 
             //assert
             var latest = result.Latest.Version.ToString();
@@ -137,11 +137,11 @@ namespace LibYear.Lib.Tests
             metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
-            var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
-            var v2 = new VersionInfo(new SemanticVersion(2, 3, 4), new DateTime(2016, 1, 1));
+            var v1 = new VersionInfo(new NuGetVersion(1, 2, 3), new DateTime(2015, 1, 1));
+            var v2 = new VersionInfo(new NuGetVersion(2, 3, 4), new DateTime(2016, 1, 1));
             var versionCache = new Dictionary<string, IList<VersionInfo>> { { "test", new List<VersionInfo> { v1, v2 } } };
             var checker = new PackageVersionChecker(metadataResource, versionCache);
-            var project = new TestProjectFile("test", new Dictionary<string, SemanticVersion> { { "test", new SemanticVersion(1, 2, 3) } });
+            var project = new TestProjectFile("test", new Dictionary<string, NuGetVersion> { { "test", new NuGetVersion(1, 2, 3) } });
 
             //act
             var packages = checker.GetPackages(new[] { project });

--- a/test/LibYear.Lib.Tests/PackageVersionCheckerTests.cs
+++ b/test/LibYear.Lib.Tests/PackageVersionCheckerTests.cs
@@ -20,7 +20,7 @@ namespace LibYear.Lib.Tests
             //arrange
             var metadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("test", new NuGetVersion(1, 2, 3))).Build();
             var metadataResource = Substitute.For<PackageMetadataResource>();
-            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
+            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(new List<IPackageSearchMetadata> { metadata });
 
             var checker = new PackageVersionChecker(metadataResource, new Dictionary<string, IList<VersionInfo>>());
@@ -38,7 +38,7 @@ namespace LibYear.Lib.Tests
             //arrange
             var metadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("test", new NuGetVersion(1, 2, 3))).Build();
             var metadataResource = Substitute.For<PackageMetadataResource>();
-            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
+            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
             var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
@@ -60,7 +60,7 @@ namespace LibYear.Lib.Tests
             //arrange
             var metadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("test", new NuGetVersion(1, 2, 3))).Build();
             var metadataResource = Substitute.For<PackageMetadataResource>();
-            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
+            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
             var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
@@ -82,7 +82,7 @@ namespace LibYear.Lib.Tests
             //arrange
             var metadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("test", new NuGetVersion(1, 2, 3))).Build();
             var metadataResource = Substitute.For<PackageMetadataResource>();
-            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
+            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
             var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));
@@ -134,7 +134,7 @@ namespace LibYear.Lib.Tests
             //arrange
             var metadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("test", new NuGetVersion(1, 2, 3))).Build();
             var metadataResource = Substitute.For<PackageMetadataResource>();
-            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
+            metadataResource.GetMetadataAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<SourceCacheContext>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
                 .Returns(m => new List<IPackageSearchMetadata> { metadata }, m => throw new Exception(":("));
 
             var v1 = new VersionInfo(new SemanticVersion(1, 2, 3), new DateTime(2015, 1, 1));

--- a/test/LibYear.Lib.Tests/ProjectFileManagerTests.cs
+++ b/test/LibYear.Lib.Tests/ProjectFileManagerTests.cs
@@ -139,7 +139,7 @@ namespace LibYear.Lib.Tests
                 {
                     new TestProjectFile("test1"), new List<Result>
                     {
-                        new Result("test1", new VersionInfo(new SemanticVersion(0, 1, 0), DateTime.Today), new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today)),
+                        new Result("test1", new VersionInfo(new NuGetVersion(0, 1, 0), DateTime.Today), new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today)),
                     }
                 }
             };

--- a/test/LibYear.Lib.Tests/ResultTests.cs
+++ b/test/LibYear.Lib.Tests/ResultTests.cs
@@ -10,8 +10,8 @@ namespace LibYear.Lib.Tests
         public void YearsBehindCalculatedCorrectly()
         {
             //arrange
-            var installed = new VersionInfo(new SemanticVersion(1, 0, 0), new DateTime(2015, 1, 1));
-            var latest = new VersionInfo(new SemanticVersion(2, 0, 0), new DateTime(2016, 1, 1));
+            var installed = new VersionInfo(new NuGetVersion(1, 0, 0), new DateTime(2015, 1, 1));
+            var latest = new VersionInfo(new NuGetVersion(2, 0, 0), new DateTime(2016, 1, 1));
 
             //act
             var result = new Result("test", installed, latest);

--- a/test/LibYear.Lib.Tests/TestProjectFile.cs
+++ b/test/LibYear.Lib.Tests/TestProjectFile.cs
@@ -7,9 +7,9 @@ namespace LibYear.Lib.Tests
     public class TestProjectFile : IProjectFile
     {
         public string FileName { get; }
-        public IDictionary<string, SemanticVersion> Packages { get; }
+        public IDictionary<string, NuGetVersion> Packages { get; }
 
-        public TestProjectFile(string fileName, IDictionary<string, SemanticVersion> packages = null)
+        public TestProjectFile(string fileName, IDictionary<string, NuGetVersion> packages = null)
         {
             FileName = fileName;
             Packages = packages;

--- a/test/LibYear.Tests/RunnerTests.cs
+++ b/test/LibYear.Tests/RunnerTests.cs
@@ -53,7 +53,7 @@ namespace LibYear.App.Tests
             var projectFile = new TestProjectFile("test project");
             var results = new Dictionary<IProjectFile, IEnumerable<Result>>
             {
-                { projectFile, new[] { new Result("test1", new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today), new VersionInfo(new SemanticVersion(1,2,3), DateTime.Today) ) } }
+                { projectFile, new[] { new Result("test1", new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today), new VersionInfo(new NuGetVersion(1,2,3), DateTime.Today) ) } }
             };
             checker.GetPackages(Arg.Any<IEnumerable<IProjectFile>>()).Returns(results);
 
@@ -77,7 +77,7 @@ namespace LibYear.App.Tests
             var projectFile = new TestProjectFile("test project");
             var results = new Dictionary<IProjectFile, IEnumerable<Result>>
             {
-                { projectFile, new[] { new Result("test1", new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today), new VersionInfo(new SemanticVersion(1,2,3), DateTime.Today) ) } }
+                { projectFile, new[] { new Result("test1", new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today), new VersionInfo(new NuGetVersion(1,2,3), DateTime.Today) ) } }
             };
             checker.GetPackages(Arg.Any<IEnumerable<IProjectFile>>()).Returns(results);
 
@@ -102,8 +102,8 @@ namespace LibYear.App.Tests
             var projectFile2 = new TestProjectFile("test project 2");
             var results = new Dictionary<IProjectFile, IEnumerable<Result>>
             {
-                { projectFile1, new[] { new Result("test1", new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today), new VersionInfo(new SemanticVersion(1,2,3), DateTime.Today) ) } },
-                { projectFile2, new[] { new Result("test1", new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today), new VersionInfo(new SemanticVersion(1,2,3), DateTime.Today) ) } }
+                { projectFile1, new[] { new Result("test1", new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today), new VersionInfo(new NuGetVersion(1,2,3), DateTime.Today) ) } },
+                { projectFile2, new[] { new Result("test1", new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today), new VersionInfo(new NuGetVersion(1,2,3), DateTime.Today) ) } }
             };
             checker.GetPackages(Arg.Any<IEnumerable<IProjectFile>>()).Returns(results);
 
@@ -128,7 +128,7 @@ namespace LibYear.App.Tests
             var projectFile2 = new TestProjectFile("test project 2");
             var results = new Dictionary<IProjectFile, IEnumerable<Result>>
             {
-                { projectFile1, new[] { new Result("test1", new VersionInfo(new SemanticVersion(1, 2, 3), DateTime.Today), new VersionInfo(new SemanticVersion(1,2,3), DateTime.Today) ) } },
+                { projectFile1, new[] { new Result("test1", new VersionInfo(new NuGetVersion(1, 2, 3), DateTime.Today), new VersionInfo(new NuGetVersion(1,2,3), DateTime.Today) ) } },
                 { projectFile2, new List<Result>() }
             };
             checker.GetPackages(Arg.Any<IEnumerable<IProjectFile>>()).Returns(results);


### PR DESCRIPTION
Fixes issue #17 by using `NuGetVersion` instead of `SemanticVersion`.  `NuGetVersion` inherits from `SemanticVersion` so they can be used in the same way, it just adds support for the additional revision number that's not valid in strict SemVer.

I also updated to the latest NuGet library while I was at it.