### PR TITLE
Update target version of .NET Core for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: '3.1.x'
 
     - name: Restore
       run: dotnet restore


### PR DESCRIPTION
Fixes #22.  Changes the version of .NET Core used in CI to any version of 3.1.